### PR TITLE
Mburns/lint compat bump

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,3 @@
-default["users"]["admins"] = Mash.new
-default["users"]["admins"]["group"] = "admins"
-default["users"]["admins"]["gid"] = 9001
+default['users']['admins'] = Mash.new
+default['users']['admins']['group'] = 'admins'
+default['users']['admins']['gid'] = 9001

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,9 @@
-name             'users'
-maintainer       'Rackspace'
+name 'users'
+maintainer 'Rackspace'
 maintainer_email 'chef@lists.rackspace.com'
-license          'Apache 2.0'
-description      'Installs/Configures users'
+license 'Apache 2.0'
+description 'Installs/Configures users'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.1'
+version '0.0.1'
 
-depends "chef-solo-search"
+depends 'chef-solo-search'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'chef@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures users'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.1'
+version '1.0.1'
 
 depends 'chef-solo-search'


### PR DESCRIPTION
1. runs `rubocop`
2. updates to version `1.0.x`, to make an easier migration of chef-server from current vendored version.