### PR TITLE
admins is already an array

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ele-ops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures users'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.0'
+version '1.1.1'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -102,5 +102,5 @@ end
 
 group admins_group do
   action :manage
-  members [admins]
+  members admins
 end


### PR DESCRIPTION
`admins` is already an array, this was erring by placing the `admins` array into another array leading to errors with `["username" cannot be found`